### PR TITLE
Add intro section in Spanish with references

### DIFF
--- a/referencias.bib
+++ b/referencias.bib
@@ -1,0 +1,17 @@
+@book{crank1975,
+  author    = {John Crank},
+  title     = {The Mathematics of Diffusion},
+  edition   = {2},
+  publisher = {Oxford University Press},
+  year      = {1975}
+}
+
+@article{dehghan2002,
+  author  = {Mehdi Dehghan},
+  title   = {On explicit finite difference schemes for the two-dimensional diffusion equation},
+  journal = {Numerical Methods for Partial Differential Equations},
+  year    = {2002},
+  volume  = {18},
+  number  = {3},
+  pages   = {No.~403--411}
+}

--- a/secciones/introduction.tex
+++ b/secciones/introduction.tex
@@ -1,0 +1,12 @@
+\section{Introducci\'on}
+La ecuaci\'on de difusi\'on en dos dimensiones modela la evoluci\'on temporal de una cantidad escalar $u(x,y,t)$ en un medio con coeficiente de difusi\'on $D$.  Puede escribirse como
+\begin{equation}
+    \frac{\partial u}{\partial t}=D\left(\frac{\partial^2 u}{\partial x^2}+\frac{\partial^2 u}{\partial y^2}\right).
+\end{equation}
+Esta formulaci\'on surge de la combinaci\'on de la ley de Fick con la conservaci\'on de masa, y es fundamental en mec\'anica de fluidos para describir procesos de transporte de calor, contaminantes o cantidad de movimiento.
+
+Los m\'etodos num\'ericos para resolver esta ecuaci\'on han sido estudiados extensamente desde los trabajos pioneros de \citet{crank1975}.  Aunque los esquemas impl\'icitos garantizan estabilidad incondicional, en equipos modestos su costo computacional es elevado debido a la necesidad de resolver sistemas lineales en cada paso de tiempo.  Alternativamente, los m\'etodos expl\'icitos permiten actualizar los nodos de la malla mediante operaciones algebraicas simples, lo cual resulta atractivo para c\'odigos educativos y entornos de c\'omputo limitados.
+
+Este proyecto compara tres variantes expl\'icitas implementadas en Python: el esquema FTCS tradicional de cinco puntos, una extensi\'on de nueve puntos y el m\'etodo de trece puntos propuesto por \citet{dehghan2002}.  Nuestro objetivo es evaluar su eficiencia y precisi\'on sin recurrir a mallas ni solucionadores externos, de modo que el estudiante pueda replicar los c\'alculos y apreciar las diferencias de rendimiento.
+
+En las siguientes secciones se detalla la formulaci\'on de cada esquema, su implementaci\'on vectorizada y los experimentos comparativos realizados.


### PR DESCRIPTION
## Summary
- add full Spanish introduction focusing on diffusion equation and Python schemes
- cite Crank and Dehghan
- populate bibliography file with Crank and Dehghan entries

## Testing
- `pytest -q`
- `pdflatex -interaction=nonstopmode paper.tex` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c4bbcfe888321aa7ccaffb3623069